### PR TITLE
Sg penalty

### DIFF
--- a/R/clean_pbp.R
+++ b/R/clean_pbp.R
@@ -13,7 +13,7 @@
 #'
 
 clean_pbp_dat <- function(raw_df) {
-  #-- add change of possession to df
+  ## add change of possession to df
   raw_df <- raw_df %>%
     mutate(half = ifelse(period <= 2, 1, 2)) %>%
     group_by(game_id, half) %>%
@@ -79,18 +79,28 @@ clean_pbp_dat <- function(raw_df) {
   raw_df$play_type[rush_td_sq] == "Rushing Touchdown"
 
   ## penalty detection
+  #-- penalty in play text
   pen_text = str_detect(raw_df$play_text, "Penalty") |
     str_detect(raw_df$play_text, "penalty") |
     str_detect(raw_df$play_text, "PENALTY")
+  #-- declined in play text
+  pen_declined_text = str_detect(raw_df$play_text,"declined")|
+    str_detect(raw_df$play_text,"Declined")|
+    str_detect(raw_df$play_text,"DECLINED")
+  #-- penalty play_types
   pen_type = raw_df$play_type == "Penalty"  | raw_df$play_type == "penalty"
+  #-- penalty_flag T/F flag conditions
   raw_df$penalty_flag = F
   raw_df$penalty_flag[pen_type] <- T
   raw_df$penalty_flag[pen_text] <- T
+  #-- penalty_declined T/F flag conditions
+  raw_df$penalty_declined = F
+  raw_df$penalty_declined[pen_text & pen_declined_text] <- T
+  raw_df$penalty_declined[pen_type & pen_declined_text] <- T
 
   ## kickoff down adjustment
-  raw_df = raw_df %>% mutate(down = ifelse(down == 5 &
-                                             str_detect(play_type, "Kickoff"), 1, down))
-
+  raw_df = raw_df %>%
+    mutate(down = ifelse(down == 5 & str_detect(play_type, "Kickoff"), 1, down))
 
   return(raw_df)
 }

--- a/R/clean_pbp.R
+++ b/R/clean_pbp.R
@@ -13,64 +13,64 @@
 #'
 
 clean_pbp_dat <- function(raw_df) {
-  ## add change of possession to df
+  ## add change of possession to df----
   raw_df <- raw_df %>%
     mutate(half = ifelse(period <= 2, 1, 2)) %>%
     group_by(game_id, half) %>%
     mutate(
-      #-- ball changes hand
+      #-- ball changes hand----
       change_of_poss = ifelse(offense_play == lead(offense_play, order_by = id_play), 0, 1),
       change_of_poss = ifelse(is.na(change_of_poss), 0, change_of_poss)
     ) %>% ungroup() %>% arrange(game_id, id_play)
 
   ## vectors
-  #-- touchdowns
+  #-- touchdowns----
   td_e = str_detect(raw_df$play_text, "TD") |
     str_detect(raw_df$play_text, "Touchdown") |
     str_detect(raw_df$play_text, "TOUCHDOWN") |
     str_detect(raw_df$play_text, "touchdown")
 
-  #-- kicks/punts
+  #-- kicks/punts----
   kick_vec = str_detect(raw_df$play_text, "KICK") &
     !is.na(raw_df$play_text)
   punt_vec = (str_detect(raw_df$play_text, "Punt") |
                 str_detect(raw_df$play_text, "punt")) &
     !is.na(raw_df$play_text)
-  #-- fumbles
+  #-- fumbles----
   fumble_vec = str_detect(raw_df$play_text, "fumble")
-  #-- pass/rush
+  #-- pass/rush----
   rush_vec = raw_df$play_type == "Rush"
   pass_vec = raw_df$play_type == "Pass Reception"
-  #-- sacks
-  #- only want non-safety sacks, otherwise would be an additional condition
+  #-- sacks----
+  #- only want non-safety sacks, otherwise would be an additional condition----
   sack_vec = raw_df$play_type == "Sack" |
     raw_df$play_type == "Sack Touchdown"
   #-- change of possession
   poss_change_vec = raw_df$change_of_poss == 1
 
-  ## Fix strip-sacks to fumbles
+  ## Fix strip-sacks to fumbles----
   raw_df$play_type[fumble_vec &
                      sack_vec & poss_change_vec & !td_e] <-
     "Fumble Recovery (Opponent)"
   raw_df$play_type[fumble_vec & sack_vec & td_e] <-
     "Fumble Recovery (Opponent) Touchdown"
 
-  ## touchdown check, want where touchdowns aren't in the play_type
+  ## touchdown check, want where touchdowns aren't in the play_type----
   td_check = !str_detect(raw_df$play_type, "Touchdown")
-  #-- fix kickoff fumble return TDs
+  #-- fix kickoff fumble return TDs----
   raw_df$play_type[kick_vec & fumble_vec & td_e & td_check] <-
     paste0(raw_df$play_type[kick_vec &
                               fumble_vec &
                               td_e & td_check], " Touchdown")
-  #-- fix punt return TDs
+  #-- fix punt return TDs----
   raw_df$play_type[punt_vec & td_e & td_check] <-
     paste0(raw_df$play_type[punt_vec &
                               td_e & td_check], " Touchdown")
-  #-- fix rush/pass tds that aren't explicit
+  #-- fix rush/pass tds that aren't explicit----
   raw_df$play_type[td_e & rush_vec] = "Rushing Touchdown"
   raw_df$play_type[td_e & pass_vec] = "Passing Touchdown"
 
-  #-- fix duplicated TD play_type labels
+  #-- fix duplicated TD play_type labels----
   pun_td_sq = (raw_df$play_type == "Punt Touchdown Touchdown")
   raw_df$play_type[pun_td_sq] <- "Punt Touchdown"
   fum_td_sq = (raw_df$play_type == "Fumble Return Touchdown Touchdown")
@@ -78,17 +78,33 @@ clean_pbp_dat <- function(raw_df) {
   rush_td_sq = (raw_df$play_type == "Rushing Touchdown Touchdown")
   raw_df$play_type[rush_td_sq] == "Rushing Touchdown"
 
-  ## penalty detection
-  #-- penalty in play text
+  ## penalty detection-----
+  #-- penalty in play text----
   pen_text = str_detect(raw_df$play_text, "Penalty") |
     str_detect(raw_df$play_text, "penalty") |
     str_detect(raw_df$play_text, "PENALTY")
-  #-- declined in play text
+  #-- declined in play text----
   pen_declined_text = str_detect(raw_df$play_text,"declined")|
     str_detect(raw_df$play_text,"Declined")|
     str_detect(raw_df$play_text,"DECLINED")
+  #--NO PLAY in play text----
+  pen_no_play_text = str_detect(raw_df$play_text,"no play")|
+    str_detect(raw_df$play_text,"No Play")|
+    str_detect(raw_df$play_text,"NO PLAY")
+  #--off-setting in play text----
+  pen_offset_text = str_detect(raw_df$play_text,"off-setting")|
+    str_detect(raw_df$play_text,"Off-Setting")|
+    str_detect(raw_df$play_text,"OFF-SETTING")
+  pen_1st_down_text = str_detect(raw_df$play_text,"1st down")|
+    str_detect(raw_df$play_text,"1st Down")|
+    str_detect(raw_df$play_text,"1st DOWN")|
+    str_detect(raw_df$play_text,"1ST Down")|
+    str_detect(raw_df$play_text,"1ST down")|
+    str_detect(raw_df$play_text,"1ST DOWN")
+
   #-- penalty play_types
   pen_type = raw_df$play_type == "Penalty"  | raw_df$play_type == "penalty"
+
   #-- penalty_flag T/F flag conditions
   raw_df$penalty_flag = F
   raw_df$penalty_flag[pen_type] <- T
@@ -97,6 +113,18 @@ clean_pbp_dat <- function(raw_df) {
   raw_df$penalty_declined = F
   raw_df$penalty_declined[pen_text & pen_declined_text] <- T
   raw_df$penalty_declined[pen_type & pen_declined_text] <- T
+  #-- penalty_no_play T/F flag conditions
+  raw_df$penalty_no_play = F
+  raw_df$penalty_no_play[pen_text & pen_no_play_text] <- T
+  raw_df$penalty_no_play[pen_type & pen_no_play_text] <- T
+  #-- penalty_offset T/F flag conditions
+  raw_df$penalty_offset = F
+  raw_df$penalty_offset[pen_text & pen_offset_text] <- T
+  raw_df$penalty_offset[pen_type & pen_offset_text] <- T
+  #-- penalty_1st_conv T/F flag conditions
+  raw_df$penalty_1st_conv = F
+  raw_df$penalty_1st_conv[pen_text & pen_1st_down_text] <- T
+  raw_df$penalty_1st_conv[pen_type & pen_1st_down_text] <- T
 
   ## kickoff down adjustment
   raw_df = raw_df %>%

--- a/R/ep_calcs.R
+++ b/R/ep_calcs.R
@@ -277,7 +277,7 @@ prep_pbp_df <- function(df) {
       half = ifelse(period <= 2, 1, 2),
       new_id = gsub(pattern = unique(game_id), "", x = id_play),
       new_id = as.numeric(new_id),
-      log_ydstogo = log(distance),
+      log_ydstogo = ifelse(distance ==0,log(0.5),log(distance)),
       down = ifelse(down == 5 &
                       str_detect(play_type, "Kickoff"),1, down)
     ) %>% filter(period <= 4, down > 0) %>%
@@ -356,6 +356,7 @@ epa_fg_probs <- function(dat, current_probs, fg_mod) {
 }
 
 prep_df_epa2 <- function(dat) {
+  ##--Play type vectors------
   turnover_play_type = c(
     "Blocked Field Goal",
     "Blocked Field Goal Touchdown",
@@ -376,36 +377,6 @@ prep_df_epa2 <- function(dat) {
     "Sack Touchdown",
     "Uncategorized Touchdown"
   )
-
-  dat = dat %>%
-    mutate_at(vars(clock.minutes, clock.seconds), ~ replace_na(., 0)) %>%
-    mutate(
-      yards_to_goal = as.numeric(yards_to_goal),
-      distance = distance,
-      yards_gained = as.numeric(yards_gained),
-      start_yardline = as.numeric(start_yardline),
-      start_yards_to_goal = as.numeric(start_yards_to_goal),
-      end_yards_to_goal = as.numeric(end_yards_to_goal),
-      clock.minutes = ifelse(period %in% c(1, 3), 15 + clock.minutes, clock.minutes),
-      raw_secs = clock.minutes * 60 + clock.seconds,
-      half = ifelse(period <= 2, 1, 2),
-      new_yardline = 0,
-      new_down = 0,
-      new_distance = 0
-      #log_ydstogo = 0
-    )
-
-  turnover_ind = dat$play_type %in% turnover_play_type
-  dat$turnover = 0
-
-  new_offense = !(dat$offense_play == lead(dat$offense_play,order_by = dat$id_play))
-  #fourth_down = dat$down == 4,  & fourth_down
-  t_ind = turnover_ind | (new_offense)
-
-  dat$turnover[t_ind] <- 1
-
-  #--play_type vectors------
-
   defense_score_vec = c(
     "Blocked Punt Touchdown",
     "Blocked Field Goal Touchdown",
@@ -464,7 +435,34 @@ prep_df_epa2 <- function(dat) {
     "Kickoff Return Touchdown",
     "Kickoff Touchdown"
   )
-  #----
+  dat = dat %>%
+    mutate_at(vars(clock.minutes, clock.seconds), ~ replace_na(., 0)) %>%
+    mutate(
+      yards_to_goal = as.numeric(yards_to_goal),
+      distance = as.numeric(distance),
+      yards_gained = as.numeric(yards_gained),
+      start_yardline = as.numeric(start_yardline),
+      start_yards_to_goal = as.numeric(start_yards_to_goal),
+      end_yards_to_goal = as.numeric(end_yards_to_goal),
+      clock.minutes = ifelse(period %in% c(1, 3), 15 + clock.minutes, clock.minutes),
+      raw_secs = clock.minutes * 60 + clock.seconds,
+      half = ifelse(period <= 2, 1, 2),
+      new_yardline = 0,
+      new_down = 0,
+      new_distance = 0
+      #log_ydstogo = 0
+    )
+
+  turnover_ind = dat$play_type %in% turnover_play_type
+  dat$turnover = 0
+
+  new_offense = !(dat$offense_play == lead(dat$offense_play,order_by = dat$id_play))
+  #fourth_down = dat$down == 4,  & fourth_down
+  t_ind = turnover_ind | (new_offense)
+
+  dat$turnover[t_ind] <- 1
+
+  #--Begin _after dataframe prep and manipulation-----
   dat = dat %>% group_by(game_id, half) %>%
     dplyr::arrange(id_play, .by_group = TRUE) %>%
     mutate(
@@ -476,7 +474,9 @@ prep_df_epa2 <- function(dat) {
         0
       ),
       down = as.numeric(down),
-      new_down = case_when(
+#--New Down-----
+      new_down = as.numeric(case_when(
+      ##--Penalty Cases (new_down)-----
         # 8 cases with three T/F penalty flags
         # 4 cases in 1
         play_type %in% penalty & penalty_1st_conv ~ 1,
@@ -494,7 +494,7 @@ prep_df_epa2 <- function(dat) {
         play_type %in% penalty & penalty_declined &
           penalty_offset & !penalty_1st_conv &
           yards_gained > distance ~ 1,
-        # only penalty declined true (1 case, split in three)
+        # only penalty declined true, same logic as prior (1 case, split in three)
         play_type %in% penalty & penalty_declined &
           !penalty_offset & !penalty_1st_conv &
           yards_gained < distance & down <= 3 ~ down+1,
@@ -504,51 +504,57 @@ prep_df_epa2 <- function(dat) {
         play_type %in% penalty & penalty_declined &
           !penalty_offset & !penalty_1st_conv &
           yards_gained >= distance ~ 1,
-        # no flags true, lead on down (1 case)
+        # no other penalty flags true, lead on down (1 case)
         play_type %in% penalty & !penalty_declined &
-          !penalty_offset & !penalty_1st_conv ~ as.numeric(lead(down, order_by=id_play)),
+          !penalty_offset & !penalty_1st_conv ~ lead(down, order_by=id_play),
+      ##--Scores, kickoffs, turnovers, defensive scores----
         play_type %in% score ~ 1,
         play_type %in% kickoff ~ 1,
         play_type %in% turnover_vec ~ 1,
         play_type %in% defense_score_vec ~ 1,
+      ##--Regular Plays----
+        # regular play 1st down
         play_type %in% normalplay & yards_gained >= distance ~ 1,
-        play_type %in% normalplay & yards_gained < distance & down <= 3 ~ down + 1,
+        # iterate to next down due to not meeting the yards to gain
+        play_type %in% normalplay & yards_gained < distance & down <= 3 ~ as.integer(down) + 1,
+        # turnover on downs
         play_type %in% normalplay & yards_gained < distance & down == 4 ~ 1
-      ),
+      )),
       yards_gained = as.numeric(yards_gained),
       start_yards_to_goal = as.numeric(start_yards_to_goal),
+#--New Distance-----
       new_distance = as.numeric(case_when(
-        ##--Penalty cases----
-        #--offsetting penalties, keep same distance----
+      ##--Penalty cases (new_distance)
+        #--offsetting penalties, keep same distance
         play_type %in% penalty &
-          penalty_offset ~ distance,
-        #--penalty first down conversions, 10 or to goal----
+          penalty_offset ~ as.numeric(distance),
+        #--penalty first down conversions, 10 or to goal
         play_type %in% penalty &
-          penalty_1st_conv ~ ifelse(yards_to_goal  - yards_gained <= 10,
-                                               yards_to_goal,10),
-        #--penalty without first down conversion----
-
+          penalty_1st_conv ~ as.numeric(ifelse(yards_to_goal  - yards_gained <= 10,
+                                               as.numeric(yards_to_goal),10)),
+        #--penalty without first down conversion
         play_type %in% penalty & !penalty_declined &
           !penalty_1st_conv &
-          !penalty_offset ~ ifelse((yards_gained >= distance) &
+          !penalty_offset ~ as.numeric(ifelse((yards_gained >= distance) &
                                 (yards_to_goal - yards_gained <= 10),
-                                 yards_to_goal,10),
-
+                                as.numeric(yards_to_goal),10)),
+      ##--normal plays
         play_type %in% normalplay &
           yards_gained >= distance &
           (yards_to_goal - yards_gained >= 10) ~ 10,
         play_type %in% normalplay &
           yards_gained >= distance &
-          (yards_to_goal  - yards_gained <= 10) ~ yards_to_goal,
+          (yards_to_goal  - yards_gained <= 10) ~ as.numeric(yards_to_goal),
         play_type %in% normalplay &
-          yards_gained < distance & down <= 3 ~ distance - yards_gained,
+          yards_gained < distance & down <= 3 ~ as.numeric(distance - yards_gained),
         play_type %in% normalplay &
           yards_gained < distance &
           down == 4 & (100 - (yards_to_goal  - yards_gained) >= 10) ~ 10,
         play_type %in% normalplay &
           yards_gained < distance &
           down == 4 &
-          (100 - (yards_to_goal  - yards_gained) <= 10) ~ 100 - yards_to_goal,
+          (100 - (yards_to_goal  - yards_gained) <= 10) ~ as.numeric(100 - yards_to_goal),
+      ##--turnovers, defensive scores, scores, kickoffs
         play_type %in% turnover_vec ~ 10,
         # play_type %in% turnover_vec &
         #   (100 - (yards_to_goal + yards_gained) >= 10) ~ 10,
@@ -558,6 +564,7 @@ prep_df_epa2 <- function(dat) {
         play_type %in% score ~ 0,
         play_type %in% kickoff ~ 10
       )),
+#--New Yardline----
       new_yardline = as.numeric(case_when(
         play_type %in% penalty & penalty_offset ~ yards_to_goal,
         play_type %in% penalty & !penalty_offset ~ yards_to_goal - yards_gained,
@@ -565,11 +572,11 @@ prep_df_epa2 <- function(dat) {
         play_type %in% score ~ 0,
         play_type %in% defense_score_vec ~ 0,
         play_type %in% kickoff ~ start_yards_to_goal,
-        play_type %in% turnover_vec ~ 100 - yards_to_goal + yards_gained,
+        play_type %in% turnover_vec ~ 100 - yards_to_goal + yards_gained
       )),
 
       new_TimeSecsRem = ifelse(!is.na(lead(TimeSecsRem,order_by=id_play)),lead(TimeSecsRem,order_by=id_play),0),
-      new_log_ydstogo = ifelse(new_distance == 0, log(0.5),log(new_distance)),
+      new_log_ydstogo = ifelse(new_distance == 0, log(1),log(new_distance)),
       new_Goal_To_Go = ifelse(new_yardline <= new_distance, TRUE, FALSE),
       # new under two minute warnings
       new_Under_two = new_TimeSecsRem <= 120,
@@ -600,7 +607,6 @@ prep_df_epa2 <- function(dat) {
     dat[punt_ind, "new_yardline"] = 100 - ifelse(punt_yd_line > 50,
                                                  (punt_yd_line - yds_punted),
                                                  (punt_yd_line + yds_punted))
-
   }
 
 


### PR DESCRIPTION
**clean_pbp.R**

1. Add penalty declined flag
2. Add penalty no play flag
3. Add penalty off-setting flag
4. Add penalty 1st down conversion  flag
5. Add comments/fix style stuff?

**ep_calcs.R**

1. Add order_by = id_play to all lead functions out of caution.
2. Add negligibly important penalty vector and move all play_type vecs to start of function
3. Add penalty logic to pred_df_epa2 function for the following variables:
   -   new_down
   -   new_distance
   -   new_yardline

4.  return penalty_flag and penalty_declined columns from prep_df_epa2 into return df from cfb_pbp_data function.
5. remove kickoff down ==5 ifelse statement. It doesn't feel like it needs to be in there and causes problems as is. Was introduced into the prep_df_epa2 function code 4 days ago, not sure why.